### PR TITLE
Allow access to element content description attribute directly

### DIFF
--- a/bootstrap/src/io/appium/android/bootstrap/AndroidElement.java
+++ b/bootstrap/src/io/appium/android/bootstrap/AndroidElement.java
@@ -187,6 +187,8 @@ public class AndroidElement {
       if (res.equals("")) {
         res = getText();
       }
+    } else if (attr.equals("contentDescription")) {
+      res = getContentDesc();
     } else if (attr.equals("text")) {
       res = getText();
     } else if (attr.equals("className")) {

--- a/bootstrap/src/io/appium/android/bootstrap/handler/GetAttribute.java
+++ b/bootstrap/src/io/appium/android/bootstrap/handler/GetAttribute.java
@@ -49,8 +49,9 @@ public class GetAttribute extends CommandHandler {
       try {
         final AndroidElement el = command.getElement();
         final String attr = params.get("attribute").toString();
-        if (attr.equals("name") || attr.equals("text")
-            || attr.equals("className") || attr.equals("resourceId")) {
+        if (attr.equals("name") || attr.equals("contentDescription")
+             || attr.equals("text") || attr.equals("className")
+             || attr.equals("resourceId")) {
           return getSuccessResult(el.getStringAttribute(attr));
         } else {
           return getSuccessResult(String.valueOf(el.getBoolAttribute(attr)));


### PR DESCRIPTION
It is confusing to users (see appium/appium#5142) to not be able to get the content description directly, but to have to get the `name` attribute. Add `contentDescription` attribute.

Original PR: https://github.com/appium/appium/pull/5189
Sub PR with test: appium/appium-android-driver#58
