### PR TITLE
Remove socket timeout + cleaned up socket

### DIFF
--- a/lib/bootstrap.js
+++ b/lib/bootstrap.js
@@ -90,17 +90,12 @@ class AndroidBootstrap {
     }
   }
 
-  async sendCommand (type, extra = {}, cmdTimeout = 10000) {
+  async sendCommand (type, extra = {}) {
     if (!this.socketClient) {
       throw new Error('Socket connection closed unexpectedly');
     }
 
     return await new Promise ((resolve, reject) => {
-      // set up timeout
-      setTimeout(() => {
-        reject(new Error(`Bootstrap server did not respond in ${cmdTimeout} ms`));
-      }, cmdTimeout);
-
       let cmd = Object.assign({cmd: type}, extra);
       let cmdJson = `${JSON.stringify(cmd)} \n`;
       log.debug(`Sending command to android: ${_.trunc(cmdJson, 1000).trim()}`);
@@ -111,6 +106,9 @@ class AndroidBootstrap {
         log.debug("Received command result from bootstrap");
         try {
           streamData = JSON.parse(streamData + data);
+          // we successfully parsed JSON so we've got all the data,
+          // remove the socket listener and evaluate
+          this.socketClient.removeAllListeners('data');
           if (streamData.status === 0) {
             resolve(streamData.value);
           }

--- a/test/unit/bootstrap-specs.js
+++ b/test/unit/bootstrap-specs.js
@@ -45,14 +45,6 @@ describe('AndroidBootstrap', function () {
     });
   }));
   describe("sendCommand", () => {
-    it("should timeout", async function () {
-      let conn = new events.EventEmitter();
-      conn.write = _.noop;
-      conn.setEncoding = _.noop;
-      androidBootstrap.socketClient = conn;
-      await androidBootstrap.sendCommand(COMMAND_TYPES.ACTION, {action: 'getDataDir'}, 1000)
-        .should.eventually.be.rejectedWith("Bootstrap");
-    });
     it("should successfully return after receiving data from bootstrap in parts", async function () {
       let conn = new events.EventEmitter();
       conn.write = _.noop;


### PR DESCRIPTION
- Bootstrap was throwing an error for commands taking >= 10 seconds. Some commands legitimately take longer than 10 seconds.
- Socket wasn't cleaning up after itself, resulting in memory leak warnings.

For comparison, 1.4 was never setting a timeout. It was simply spinning: https://github.com/appium/appium/blob/6a516bc6f32febc2c175f24332e7708d3e9be62a/lib/devices/android/uiautomator.js#L121-L133

I've run the full e2e suite of 1.4 against these changes with success.

@jlipps - please critically review.

cc) @imurchie 
