### PR TITLE
Add adb as parameter to constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The commands are sent through the JavaScript interface.
 
 ### Usage
 
-The module provides an `AndroidBootstrap` class, which is instantiated with a system port (defaults to `4724`) and an optional web socket. The object then has four `async` methods:
+The module provides an `AndroidBootstrap` class, which is instantiated with an instance of [appium-adb](https://github.com/appium/appium-adb), a system port (defaults to `4724`) and an optional web socket. The object then has four `async` methods:
 
 `async start (appPackage, disableAndroidWatchers)`
 

--- a/lib/bootstrap.js
+++ b/lib/bootstrap.js
@@ -1,5 +1,4 @@
 import UiAutomator from 'appium-uiautomator';
-import ADB from 'appium-adb';
 import net from 'net';
 import path from 'path';
 import _ from 'lodash';
@@ -15,7 +14,8 @@ const COMMAND_TYPES = {
 };
 
 class AndroidBootstrap {
-  constructor (systemPort = 4724, webSocket = undefined) {
+  constructor (adb, systemPort = 4724, webSocket = undefined) {
+    this.adb = adb;
     this.systemPort = systemPort;
     this.webSocket = webSocket;
     this.onUnexpectedShutdown = new B(() => {}).cancellable();
@@ -143,7 +143,6 @@ class AndroidBootstrap {
 
   // this helper function makes unit testing easier.
   async init () {
-    this.adb = await ADB.createADB();
     this.uiAutomator = new UiAutomator(this.adb);
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,9 +25,8 @@
     "lib": "lib"
   },
   "dependencies": {
-    "appium-adb": "^2.0.1",
     "appium-logger": "^2.0.0",
-    "appium-uiautomator": "^1.0.0",
+    "appium-uiautomator": "^1.0.1",
     "babel-runtime": "=5.8.24",
     "bluebird": "^2.10.2",
     "lodash": "^3.10.0",
@@ -42,6 +41,7 @@
     "watch": "./node_modules/.bin/gulp"
   },
   "devDependencies": {
+    "appium-adb": "^2.0.2",
     "appium-gulp-plugins": "^1.3.11",
     "appium-test-support": "^0.0.5",
     "chai": "^3.3.0",

--- a/test/functional/bootstrap-e2e-specs.js
+++ b/test/functional/bootstrap-e2e-specs.js
@@ -25,7 +25,7 @@ describe('Android Bootstrap', function () {
     await adb.install(apiDemos);
     await adb.startApp({pkg: packageName,
                         activity: activityName});
-    androidBootstrap = new AndroidBootstrap(systemPort);
+    androidBootstrap = new AndroidBootstrap(adb, systemPort);
     await androidBootstrap.start('com.example.android.apis', false);
   });
   after(async ()=> {

--- a/test/unit/bootstrap-specs.js
+++ b/test/unit/bootstrap-specs.js
@@ -15,18 +15,17 @@ import _ from 'lodash';
 chai.should();
 chai.use(chaiAsPromised);
 
-describe('AndroidBootstrap', function () {
+describe('AndroidBootstrap', async function () {
   const systemPort = 4724;
-  let androidBootstrap = new AndroidBootstrap(systemPort),
-      adb = new ADB(),
-      uiAutomator = new UiAutomator(adb);
+  let adb = new ADB();
+  let androidBootstrap = new AndroidBootstrap(adb, systemPort);
+  let uiAutomator = new UiAutomator(adb);
 
   describe("start", withSandbox({mocks: {adb, uiAutomator, net, androidBootstrap}}, (S) => {
     it("should return a subProcess", async function () {
       let conn = new events.EventEmitter();
       const appPackage = 'com.example.android.apis',
             disableAndroidWatchers = false;
-      androidBootstrap.adb = adb;
       androidBootstrap.uiAutomator = uiAutomator;
       S.mocks.androidBootstrap.expects('init').once()
         .returns('');


### PR DESCRIPTION
Pass in instance of `appium-adb` to constructor, so that it is not the bare instance that gets used (which makes it so that multiple devices cannot be connected).
