### PR TITLE
Windows: catch socket error on abd restart

### DIFF
--- a/lib/bootstrap.js
+++ b/lib/bootstrap.js
@@ -19,6 +19,7 @@ class AndroidBootstrap {
     this.systemPort = systemPort;
     this.webSocket = webSocket;
     this.onUnexpectedShutdown = new B(() => {}).cancellable();
+    this.ignoreUnexpectedShutdown = false;
   }
 
   async start (appPackage, disableAndroidWatchers = false, acceptSslCerts = false) {
@@ -153,6 +154,15 @@ class AndroidBootstrap {
   // this helper function makes unit testing easier.
   async init () {
     this.uiAutomator = new UiAutomator(this.adb);
+  }
+
+  set ignoreUnexpectedShutdown (ignore) {
+    log.debug(`${ignore ? 'Ignoring' : 'Watching for'} bootstrap disconnect`);
+    this._ignoreUnexpectedShutdown = ignore;
+  }
+
+  get ignoreUnexpectedShutdown () {
+    return this._ignoreUnexpectedShutdown;
   }
 }
 

--- a/lib/bootstrap.js
+++ b/lib/bootstrap.js
@@ -80,6 +80,12 @@ class AndroidBootstrap {
       return await new Promise ((resolve, reject) => {
         try {
           this.socketClient = net.connect(this.systemPort);
+          // Windows: the socket errors out when ADB restarts. Let's catch it to avoid crashing.
+          this.socketClient.on('error', (err) => {
+            if (!this.ignoreUnexpectedShutdown) {
+              throw new Error(`Android boostrap socket crashed: ${err}`);
+            }
+          });
           this.socketClient.once('connect', () => {
             log.info("Android bootstrap socket is now connected");
             resolve();


### PR DESCRIPTION
For reference: https://github.com/appium/appium-android-driver/pull/106

Resolves: https://github.com/appium/appium/issues/6113

We were using [Domains](https://nodejs.org/api/domain.html) to catch this error in 1.4. We're no longer relying on domains as of 1.5.

Please don't merge. Running tests.
