### PR TITLE
Add support for context in xpath find strategy

### DIFF
--- a/bootstrap/src/io/appium/android/bootstrap/handler/Find.java
+++ b/bootstrap/src/io/appium/android/bootstrap/handler/Find.java
@@ -145,7 +145,7 @@ public class Find extends CommandHandler {
     boolean found = false;
     try {
       Object result = null;
-      final List<UiSelector> selectors = getSelectors(strategy, text, multiple);
+      final List<UiSelector> selectors = getSelectors(strategy, text, multiple, contextId);
       if (!multiple) {
         for (int i = 0; i < selectors.size() && !found; i++) {
           try {
@@ -262,7 +262,7 @@ public class Find extends CommandHandler {
    * @throws ElementNotFoundException
    */
   private List<UiSelector> getSelectors(final Strategy strategy,
-      final String text, final boolean many) throws InvalidStrategyException,
+      final String text, final boolean many, final String contextId) throws InvalidStrategyException,
       ElementNotFoundException, UiSelectorSyntaxException,
       ParserConfigurationException, InvalidSelectorException {
     final List<UiSelector> selectors = new ArrayList<UiSelector>();
@@ -270,7 +270,7 @@ public class Find extends CommandHandler {
 
     switch (strategy) {
       case XPATH:
-        for (final UiSelector selector : getXPathSelectors(text, many)) {
+        for (final UiSelector selector : getXPathSelectors(text, many, contextId)) {
           selectors.add(selector);
         }
         break;
@@ -382,12 +382,16 @@ public class Find extends CommandHandler {
 
   /** returns List of UiSelectors for an xpath expression **/
   private List<UiSelector> getXPathSelectors(final String expression,
-      final boolean multiple) throws ElementNotFoundException,
-      ParserConfigurationException, InvalidSelectorException {
+                                             final boolean multiple,
+                                             String contextId)
+          throws ElementNotFoundException, ParserConfigurationException, InvalidSelectorException {
+    
     final List<UiSelector> selectors = new ArrayList<UiSelector>();
 
-    final ArrayList<ClassInstancePair> pairs = XMLHierarchy
-        .getClassInstancePairs(expression);
+    final ArrayList<ClassInstancePair> pairs =
+            contextId.equals("") ?
+                    XMLHierarchy.getClassInstancePairs(expression) :
+                    XMLHierarchy.getClassInstancePairs(expression, contextId);
 
     if (!multiple) {
       if (pairs.size() == 0) {

--- a/bootstrap/src/io/appium/android/bootstrap/utils/XMLHierarchy.java
+++ b/bootstrap/src/io/appium/android/bootstrap/utils/XMLHierarchy.java
@@ -16,14 +16,16 @@
 
 package io.appium.android.bootstrap.utils;
 
-import android.graphics.Point;
 import android.os.Environment;
-import android.view.Display;
 import android.view.accessibility.AccessibilityNodeInfo;
+
+import io.appium.android.bootstrap.AndroidElement;
+import io.appium.android.bootstrap.AndroidElementsHash;
 import io.appium.android.bootstrap.exceptions.ElementNotFoundException;
 import io.appium.android.bootstrap.exceptions.InvalidSelectorException;
 import io.appium.android.bootstrap.exceptions.PairCreationException;
 import io.appium.uiautomator.core.AccessibilityNodeInfoDumper;
+import io.appium.uiautomator.core.AccessibilityNodeInfoGetter;
 import io.appium.uiautomator.core.UiAutomatorBridge;
 import org.w3c.dom.Document;
 import org.w3c.dom.NamedNodeMap;
@@ -64,6 +66,26 @@ public abstract class XMLHierarchy {
     return getClassInstancePairs(exp, formattedXmlRoot);
   }
 
+  public static ArrayList<ClassInstancePair> getClassInstancePairs(final String xpathExpression, final String contextId)
+          throws InvalidSelectorException, ElementNotFoundException {
+    AndroidElement contextElement = AndroidElementsHash.getInstance().getElement(contextId);
+    AccessibilityNodeInfo contextNode = AccessibilityNodeInfoGetter.fromUiObject(contextElement.getUiObject());
+
+    XPath xpath = XPathFactory.newInstance().newXPath();
+    XPathExpression exp = null;
+    try {
+      exp = xpath.compile(xpathExpression);
+    } catch (XPathExpressionException e) {
+      throw new InvalidSelectorException(e.getMessage());
+    }
+
+    Node formattedXmlRoot;
+
+    formattedXmlRoot = getFormattedXMLDoc(contextNode);
+
+    return getClassInstancePairs(exp, formattedXmlRoot);
+  }
+
   public static ArrayList<ClassInstancePair> getClassInstancePairs(XPathExpression xpathExpression, Node root) throws ElementNotFoundException {
 
     NodeList nodes;
@@ -87,7 +109,11 @@ public abstract class XMLHierarchy {
   }
 
   public static InputSource getRawXMLHierarchy() {
-    AccessibilityNodeInfo root = getRootAccessibilityNode();
+    AccessibilityNodeInfo root = getRootAccessibilityNode();    
+    return getRawXMLHierarchy(root);
+  }
+
+  public static InputSource getRawXMLHierarchy(AccessibilityNodeInfo root) {
     return serializeAccessibilityNode(root);
   }
 
@@ -119,6 +145,10 @@ public abstract class XMLHierarchy {
 
   public static Node getFormattedXMLDoc() {
     return formatXMLInput(getRawXMLHierarchy());
+  }
+
+  public static Node getFormattedXMLDoc(AccessibilityNodeInfo root) {
+    return formatXMLInput(getRawXMLHierarchy(root));
   }
 
   public static Node formatXMLInput(InputSource input) {

--- a/bootstrap/src/io/appium/android/bootstrap/utils/XMLHierarchy.java
+++ b/bootstrap/src/io/appium/android/bootstrap/utils/XMLHierarchy.java
@@ -51,19 +51,8 @@ public abstract class XMLHierarchy {
 
   public static ArrayList<ClassInstancePair> getClassInstancePairs(String xpathExpression)
           throws ElementNotFoundException, InvalidSelectorException, ParserConfigurationException {
-    XPath xpath = XPathFactory.newInstance().newXPath();
-    XPathExpression exp = null;
-    try {
-      exp = xpath.compile(xpathExpression);
-    } catch (XPathExpressionException e) {
-      throw new InvalidSelectorException(e.getMessage());
-    }
 
-    Node formattedXmlRoot;
-
-    formattedXmlRoot = getFormattedXMLDoc();
-
-    return getClassInstancePairs(exp, formattedXmlRoot);
+    return getClassInstancePairs(compileXpath(xpathExpression), getFormattedXMLDoc());
   }
 
   public static ArrayList<ClassInstancePair> getClassInstancePairs(final String xpathExpression, final String contextId)
@@ -71,6 +60,10 @@ public abstract class XMLHierarchy {
     AndroidElement contextElement = AndroidElementsHash.getInstance().getElement(contextId);
     AccessibilityNodeInfo contextNode = AccessibilityNodeInfoGetter.fromUiObject(contextElement.getUiObject());
 
+    return getClassInstancePairs(compileXpath(xpathExpression), getFormattedXMLDoc(contextNode));
+  }
+
+  private static XPathExpression compileXpath(String xpathExpression) throws InvalidSelectorException {
     XPath xpath = XPathFactory.newInstance().newXPath();
     XPathExpression exp = null;
     try {
@@ -78,12 +71,7 @@ public abstract class XMLHierarchy {
     } catch (XPathExpressionException e) {
       throw new InvalidSelectorException(e.getMessage());
     }
-
-    Node formattedXmlRoot;
-
-    formattedXmlRoot = getFormattedXMLDoc(contextNode);
-
-    return getClassInstancePairs(exp, formattedXmlRoot);
+    return exp;
   }
 
   public static ArrayList<ClassInstancePair> getClassInstancePairs(XPathExpression xpathExpression, Node root) throws ElementNotFoundException {

--- a/bootstrap/src/io/appium/uiautomator/core/AccessibilityNodeInfoGetter.java
+++ b/bootstrap/src/io/appium/uiautomator/core/AccessibilityNodeInfoGetter.java
@@ -1,0 +1,29 @@
+package io.appium.uiautomator.core;
+
+import android.view.accessibility.AccessibilityNodeInfo;
+
+import com.android.uiautomator.core.Configurator;
+import com.android.uiautomator.core.UiObject;
+
+import static io.appium.android.bootstrap.utils.ReflectionUtils.invoke;
+import static io.appium.android.bootstrap.utils.ReflectionUtils.method;
+
+/**
+ * Static helper class for getting {@link AccessibilityNodeInfo} instances.
+ *
+ * Created by guysmoilov on 2/18/2016.
+ */
+public abstract class AccessibilityNodeInfoGetter {
+
+    private static Configurator configurator = Configurator.getInstance();
+
+    /**
+     * Gets the {@link AccessibilityNodeInfo} associated with the given {@link UiObject}
+     */
+    public static AccessibilityNodeInfo fromUiObject(UiObject uiObject) {
+        return (AccessibilityNodeInfo)
+                invoke(method(UiObject.class, "findAccessibilityNodeInfo", long.class),
+                        uiObject,
+                        configurator.getWaitForSelectorTimeout());
+    }
+}


### PR DESCRIPTION
For find commands like this one:
{"cmd":"action","action":"find","params":{"strategy":"xpath","selector":"//android.widget.TextView","context":"**5**","multiple":true}}}
