### PR TITLE
Make sure child objects are within the bounds of parent on find

### DIFF
--- a/bootstrap/src/io/appium/android/bootstrap/AndroidElementsHash.java
+++ b/bootstrap/src/io/appium/android/bootstrap/AndroidElementsHash.java
@@ -16,6 +16,7 @@
 
 package io.appium.android.bootstrap;
 
+import android.graphics.Rect;
 import com.android.uiautomator.core.UiObject;
 import com.android.uiautomator.core.UiObjectNotFoundException;
 import com.android.uiautomator.core.UiSelector;
@@ -24,6 +25,8 @@ import io.appium.android.bootstrap.exceptions.ElementNotFoundException;
 import java.util.ArrayList;
 import java.util.Hashtable;
 import java.util.regex.Pattern;
+
+import io.appium.android.bootstrap.Logger;
 
 /**
  * A cache of elements that the app has seen.
@@ -96,6 +99,14 @@ public class AndroidElementsHash {
     } else {
       try {
         el = baseEl.getChild(sel);
+        // there are times when UiAutomator returns an element from another parent
+        // so we need to see if it is within the bounds of the parent
+        if (!Rect.intersects(baseEl.getBounds(), el.getBounds())) {
+            Logger.debug("UiAutomator returned a child element but it is " +
+                         "outside the bounds of the parent. Assuming no " +
+                         "child element found");
+            throw new ElementNotFoundException();
+        }
       } catch (final UiObjectNotFoundException e) {
         throw new ElementNotFoundException();
       }

--- a/bootstrap/src/io/appium/android/bootstrap/handler/Find.java
+++ b/bootstrap/src/io/appium/android/bootstrap/handler/Find.java
@@ -140,8 +140,8 @@ public class Find extends CommandHandler {
     final String text = (String) params.get("selector");
     final boolean multiple = (Boolean) params.get("multiple");
 
-    Logger.debug("Finding " + text + " using " + strategy.toString()
-        + " with the contextId: " + contextId + " multiple: " + multiple);
+    Logger.debug("Finding '" + text + "' using '" + strategy.toString()
+        + "' with the contextId: '" + contextId + "' multiple: " + multiple);
     boolean found = false;
     try {
       Object result = null;
@@ -385,7 +385,7 @@ public class Find extends CommandHandler {
                                              final boolean multiple,
                                              String contextId)
           throws ElementNotFoundException, ParserConfigurationException, InvalidSelectorException {
-    
+
     final List<UiSelector> selectors = new ArrayList<UiSelector>();
 
     final ArrayList<ClassInstancePair> pairs =


### PR DESCRIPTION
When `UiObject` can't find a child element it can sometimes grab one that fits the criteria, from another parent. One stop-gap measure to circumvent this is to make sure that a child element is within the bounds of its supposed parent.

Addresses https://github.com/appium/appium/issues/6269
