### PR TITLE
Increase key injection delay time

### DIFF
--- a/bootstrap/src/io/appium/android/bootstrap/handler/SetText.java
+++ b/bootstrap/src/io/appium/android/bootstrap/handler/SetText.java
@@ -16,7 +16,7 @@
 
 package io.appium.android.bootstrap.handler;
 
-import com.android.uiautomator.core.Configurator
+import com.android.uiautomator.core.Configurator;
 import com.android.uiautomator.core.UiDevice;
 import com.android.uiautomator.core.UiObjectNotFoundException;
 import com.android.uiautomator.core.UiSelector;

--- a/bootstrap/src/io/appium/android/bootstrap/handler/SetText.java
+++ b/bootstrap/src/io/appium/android/bootstrap/handler/SetText.java
@@ -84,6 +84,7 @@ public class SetText extends CommandHandler {
       if (!replace) {
         text = currText + text;
       }
+      Configurator.getInstance().setKeyInjectionDelay(100);
       final boolean result = el.setText(text, unicodeKeyboard);
       if (!result) {
         return getErrorResult("el.setText() failed!");

--- a/bootstrap/src/io/appium/android/bootstrap/handler/SetText.java
+++ b/bootstrap/src/io/appium/android/bootstrap/handler/SetText.java
@@ -16,6 +16,7 @@
 
 package io.appium.android.bootstrap.handler;
 
+import com.android.uiautomator.core.Configurator
 import com.android.uiautomator.core.UiDevice;
 import com.android.uiautomator.core.UiObjectNotFoundException;
 import com.android.uiautomator.core.UiSelector;


### PR DESCRIPTION
The default delay time is 0ms，that sometimes leads to wrong type-in sequence:
`xxx@host.com` --> `xxx@hos.tcom` 
 `2016-05-04 13:38:34.169` --> `2016-05-04 133:83:4.169`
Maybe the duration of type in symbol or char is diff.
Increase mKeyInjectionDelay, to ensure sendText() in right sequence.
