### PR TITLE
Converted webview elements have no resourceId package prefix and are ignored by Appium

### DIFF
--- a/bootstrap/src/io/appium/android/bootstrap/handler/Find.java
+++ b/bootstrap/src/io/appium/android/bootstrap/handler/Find.java
@@ -317,6 +317,13 @@ public class Find extends CommandHandler {
               sel = sel.instance(0);
             }
             selectors.add(sel);
+
+            // webview element ids do not have a package prefix
+            sel = sel.resourceId(text);
+            if (!many) {
+              sel = sel.instance(0);
+            }
+            selectors.add(sel);
           }
         }
 


### PR DESCRIPTION
Fix for appium/appium#6608: HTML element ids don't seem to have any package id prepended to them in the page source, so when Appium tries to prepend a package name to them, it ends up not finding them.
