### PR TITLE
Exclude tests (and fixtures) from npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -5,3 +5,4 @@ bootstrap/local.properties
 bootstrap/.classpath
 node_modules
 *.log
+test


### PR DESCRIPTION
No need to bloat the package with the apk.