### PR TITLE
add parent info in UIObject when findelements

### DIFF
--- a/bootstrap/src/io/appium/android/bootstrap/AndroidElementsHash.java
+++ b/bootstrap/src/io/appium/android/bootstrap/AndroidElementsHash.java
@@ -151,8 +151,13 @@ public class AndroidElementsHash {
     // The selector now points to an entirely different element.
     if (endsWithInstance) {
       Logger.debug("Selector ends with instance.");
+      UiObject instanceObj;
+      if (baseEl != null) {
+        instanceObj = baseEl.getChild(sel);
+      } else {
+        instanceObj = new UiObject(sel);
+      }
       // There's exactly one element when using instance.
-      UiObject instanceObj = baseEl.getChild(sel);
       if (instanceObj != null && instanceObj.exists()) {
         elements.add(addElement(instanceObj));
       }

--- a/bootstrap/src/io/appium/android/bootstrap/AndroidElementsHash.java
+++ b/bootstrap/src/io/appium/android/bootstrap/AndroidElementsHash.java
@@ -141,7 +141,7 @@ public class AndroidElementsHash {
     Logger.debug("getElements selector:" + selectorString);
     final ArrayList<AndroidElement> elements = new ArrayList<AndroidElement>();
 
-	final AndroidElement baseEl = this.getElement(key);
+    final AndroidElement baseEl = this.getElement(key);
     // If sel is UiSelector[CLASS=android.widget.Button, INSTANCE=0]
     // then invoking instance with a non-0 argument will corrupt the selector.
     //

--- a/bootstrap/src/io/appium/android/bootstrap/AndroidElementsHash.java
+++ b/bootstrap/src/io/appium/android/bootstrap/AndroidElementsHash.java
@@ -141,6 +141,7 @@ public class AndroidElementsHash {
     Logger.debug("getElements selector:" + selectorString);
     final ArrayList<AndroidElement> elements = new ArrayList<AndroidElement>();
 
+	final AndroidElement baseEl = this.getElement(key);
     // If sel is UiSelector[CLASS=android.widget.Button, INSTANCE=0]
     // then invoking instance with a non-0 argument will corrupt the selector.
     //
@@ -151,7 +152,7 @@ public class AndroidElementsHash {
     if (endsWithInstance) {
       Logger.debug("Selector ends with instance.");
       // There's exactly one element when using instance.
-      UiObject instanceObj = new UiObject(sel);
+      UiObject instanceObj = baseEl.getChild(sel);
       if (instanceObj != null && instanceObj.exists()) {
         elements.add(addElement(instanceObj));
       }
@@ -159,7 +160,6 @@ public class AndroidElementsHash {
     }
 
     UiObject lastFoundObj;
-    final AndroidElement baseEl = this.getElement(key);
 
     UiSelector tmp;
     int counter = 0;


### PR DESCRIPTION
Problem:
When executing following test:
```
WebElement a = wd.findElement(By.className("android.widget.ListView"));
List<WebElement> list = a.findElements(By.xpath("//android.widget.TextView[@text='DateActivity' and @class='android.widget.TextView' and @resource-id='android:id/text1']"));
String text = list.get(0).getAttribute("text");
```
will return the text of ListView's titile textView. But the expected result is "DateActivity".

Fix:
add parent info in getElements.

I didn't understand the comments around findElements() if endsWithInstance = true.
