### PR TITLE
if bootstrap log says [debug], use log.debug rather than log.info

### DIFF
--- a/lib/bootstrap.js
+++ b/lib/bootstrap.js
@@ -54,7 +54,14 @@ class AndroidBootstrap {
         for (let line of stdoutLines) {
           if (line.trim()) {
             if (uiautoLog.test(line)) {
-              log.info(`[BOOTSTRAP LOG] ${uiautoLog.exec(line)[1].trim()}`);
+              let innerLine = uiautoLog.exec(line)[1].trim();
+              let logMethod = log.info.bind(log);
+              // if the bootstrap log considers something debug, log that as
+              // debug and not info
+              if (/\[debug\]/.test(innerLine)) {
+                logMethod = log.debug.bind(log);
+              }
+              logMethod(`[BOOTSTRAP LOG] ${innerLine}`);
             } else {
               log.debug(`[UIAUTO STDOUT] ${line}`);
             }


### PR DESCRIPTION
fixx appium/appium#8725