### PR TITLE
Properly pass downstream error description instead of using defaults

### DIFF
--- a/lib/bootstrap.js
+++ b/lib/bootstrap.js
@@ -131,7 +131,7 @@ class AndroidBootstrap {
           if (!_.isString(streamData)) {
             log.error('Got an unexpected error inside socket listener');
             log.error(err.stack);
-            return reject(errorFromCode(13), err.message);
+            return reject(errorFromCode(13, err.message));
           }
           log.debug(`Stream still not complete, waiting up to ${SEND_COMMAND_TIMEOUT}ms for the data to arrive`);
           streamData += data;
@@ -139,7 +139,7 @@ class AndroidBootstrap {
             const errMsg = `Server socket stopped responding. The recent response was '${streamData}'`;
             log.error(errMsg);
             this.socketClient.removeAllListeners('data');
-            reject(errorFromCode(13), errMsg);
+            reject(errorFromCode(13, errMsg));
           }, SEND_COMMAND_TIMEOUT);
         }
       });

--- a/lib/bootstrap.js
+++ b/lib/bootstrap.js
@@ -126,19 +126,20 @@ class AndroidBootstrap {
           if (streamData.status === 0) {
             return resolve(streamData.value);
           }
-          reject(errorFromCode(streamData.status));
+          reject(errorFromCode(streamData.status, streamData.value));
         } catch (err) {
           if (!_.isString(streamData)) {
             log.error('Got an unexpected error inside socket listener');
             log.error(err.stack);
-            return reject(errorFromCode(13));
+            return reject(errorFromCode(13), err.message);
           }
           log.debug(`Stream still not complete, waiting up to ${SEND_COMMAND_TIMEOUT}ms for the data to arrive`);
           streamData += data;
           sendCommandTimeoutHandler = setTimeout(() => {
-            log.error(`Server socket stopped responding. The recent response was '${streamData}'`);
+            const errMsg = `Server socket stopped responding. The recent response was '${streamData}'`;
+            log.error(errMsg);
             this.socketClient.removeAllListeners('data');
-            reject(errorFromCode(13));
+            reject(errorFromCode(13), errMsg);
           }, SEND_COMMAND_TIMEOUT);
         }
       });


### PR DESCRIPTION
This is related to https://github.com/appium/appium-base-driver/pull/210